### PR TITLE
Update the latest SkiaSharp version for Linux conversion samples

### DIFF
--- a/PPTX-to-Image-conversion/Convert-PowerPoint-presentation-to-Image/Linux/Convert-PowerPoint-Presentation-to-Image/Convert-PowerPoint-Presentation-to-Image.csproj
+++ b/PPTX-to-Image-conversion/Convert-PowerPoint-presentation-to-Image/Linux/Convert-PowerPoint-Presentation-to-Image/Convert-PowerPoint-Presentation-to-Image.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0" />
     <PackageReference Include="Syncfusion.PresentationRenderer.Net.Core" Version="*" />
   </ItemGroup>
 </Project>

--- a/PPTX-to-Image-conversion/Convert-PowerPoint-presentation-to-Image/Linux/Convert-PowerPoint-Presentation-to-Image/Program.cs
+++ b/PPTX-to-Image-conversion/Convert-PowerPoint-presentation-to-Image/Linux/Convert-PowerPoint-Presentation-to-Image/Program.cs
@@ -12,7 +12,7 @@ namespace Convert_PowerPoint_Presentation_to_Image
         static void Main(string[] args)
         {
             //Open the file as Stream.
-            using (FileStream fileStreamInput = new FileStream(Path.GetFullPath(@"../../../Data/Input.pptx"), FileMode.Open, FileAccess.Read))
+            using (FileStream fileStreamInput = new FileStream(Path.GetFullPath(@"Data/Input.pptx"), FileMode.Open, FileAccess.Read))
             {
                 //Open the existing PowerPoint presentation with loaded stream.
                 using (IPresentation pptxDoc = Presentation.Open(fileStreamInput))

--- a/PPTX-to-PDF-conversion/Convert-PowerPoint-presentation-to-PDF/Linux/Convert-PowerPoint-Presentation-to-PDF/Convert-PowerPoint-Presentation-to-PDF.csproj
+++ b/PPTX-to-PDF-conversion/Convert-PowerPoint-presentation-to-PDF/Linux/Convert-PowerPoint-Presentation-to-PDF/Convert-PowerPoint-Presentation-to-PDF.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.2" />
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="7.3.0" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.6" />
     <PackageReference Include="Syncfusion.PresentationRenderer.Net.Core" Version="*" />
   </ItemGroup>

--- a/PPTX-to-PDF-conversion/Convert-PowerPoint-presentation-to-PDF/Linux/Convert-PowerPoint-Presentation-to-PDF/Program.cs
+++ b/PPTX-to-PDF-conversion/Convert-PowerPoint-presentation-to-PDF/Linux/Convert-PowerPoint-Presentation-to-PDF/Program.cs
@@ -13,7 +13,7 @@ namespace Convert_PowerPoint_Presentation_to_PDF
         static void Main(string[] args)
         {
             //Open the file as Stream
-            using (FileStream fileStreamInput = new FileStream(Path.GetFullPath(@"../../../Data/Input.pptx"), FileMode.Open, FileAccess.Read))
+            using (FileStream fileStreamInput = new FileStream(Path.GetFullPath(@"Data/Input.pptx"), FileMode.Open, FileAccess.Read))
             {
                 //Open the existing PowerPoint presentation with loaded stream.
                 using (IPresentation pptxDoc = Presentation.Open(fileStreamInput))


### PR DESCRIPTION
Update the latest SkiaSharp version for Linux conversion samples:

- PPTX to PDF
- PPTX to Image

[SkiaSharp.NativeAssets.Linux v2.88.6](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Linux/2.88.6)
[HarfBuzzSharp.NativeAssets.Linux v7.3.0](https://www.nuget.org/packages/HarfBuzzSharp.NativeAssets.Linux/7.3.0)